### PR TITLE
Only comment when there are actually files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,9 +45,12 @@ export = (app: Application) => {
                         similarFiles = similarFiles.filter((x, i, self) => {
                             return self.indexOf(x) === i;
                         });
-                        const output = `Similar files are\n${similarFiles.toString()}`;
-                        const params = context.issue({body: output});
-                        context.github.issues.createComment(params);
+
+                        if(similarFiles.length > 0) {
+                            const output = `Similar files are\n${similarFiles.toString()}`;
+                            const params = context.issue({body: output});
+                            context.github.issues.createComment(params);
+                        }
                     }
                 });
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,5 +6,23 @@ test('that we can run tests', () => {
   expect(1 + 2 + 3).toBe(6)
 })
 
+test('that empty lists do not get printed', () => {
+  let similarFiles = []
+  let ok2 = true
+  if (similarFiles.length > 0) {
+    ok2 = false
+  }
+  expect(ok2).toBe(true)
+})
+
+test('that non-empty lists do get printed', () => {
+  let similarFiles = ['pom.xml', 'other.xml']
+  let ok = false
+  if (similarFiles.length > 0) {
+    ok = true
+  }
+  expect(ok).toBe(true)
+})
+
 // For more information about testing with Jest see:
 // https://facebook.github.io/jest/


### PR DESCRIPTION
When no similar files are found, the bot will still comment with an empty message. It will just say "Similar files are".

With a simple if wrapper we should be able to only commit when there are actually similar files found.

I could not find existing tests, and I'm not really familiar with jest; so I just added two proof of concept ones.